### PR TITLE
chore(squid): 更新 squid CI 配置

### DIFF
--- a/.github/configs/squid/squid.yml
+++ b/.github/configs/squid/squid.yml
@@ -1,3 +1,7 @@
+runs_on: self-hosted
+
+build_parallelism: 2
+
 repo: https://github.com/pooneyy/Container-Images-Publisher
 
 ref: main
@@ -11,7 +15,7 @@ build_context: .github/configs/squid
 
 dockerfile: .github/configs/squid/Dockerfile
 
-architectures: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
+architectures: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/riscv64, linux/s390x
 
 # renovate: datasource=github-tags depName=squid-cache/squid
 build_args: SQUID_VERSION=7.4


### PR DESCRIPTION
- 添加 `runs_on: self-hosted` 指定自托管运行器
- 添加 `build_parallelism: 2` 设置并行构建数量
- 扩展支持的架构列表，新增 `linux/arm/v7` 和 `linux/riscv64`