### PR TITLE
build(squid): 更新 squid 构建配置至版本 7.6

### DIFF
--- a/.github/configs/squid/squid.yml
+++ b/.github/configs/squid/squid.yml
@@ -8,7 +8,7 @@ ref: main
 
 image_name: squid
 
-image_tag: 7.5.0,7.5,7,latest
+image_tag: 7.6.0,7.6,7,latest
 
 build_context: .github/configs/squid
 
@@ -16,6 +16,6 @@ dockerfile: .github/configs/squid/Dockerfile
 
 architectures: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/riscv64, linux/s390x
 
-build_args: SQUID_VERSION=7.5
+build_args: SQUID_VERSION=7.6
 
 build_target: 


### PR DESCRIPTION
- 将默认镜像标签从 7.5 更新至 7.6
- 同步更新构建参数 SQUID_VERSION 为 7.6